### PR TITLE
Remove .DS_Store from project gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-.DS_Store
 .sass_cache
 *.psd
 .tmp


### PR DESCRIPTION
OS artifacts should be excluded from a global, systemwide gitignore,
since they are specific to the user, not the project

Here's what I am using https://github.com/ivank/dotfiles/blob/master/.gitignore_global
As suggested by https://help.github.com/articles/ignoring-files/