### PR TITLE
Removed 3d transition

### DIFF
--- a/src/sass/modules/_steps.scss
+++ b/src/sass/modules/_steps.scss
@@ -5,7 +5,7 @@
     position: absolute;
     top: 50%;
     backface-visibility: hidden;
-    transform: translate3d(0, -50%, 0);
+    transform: translateY(-50%);
 
     h2 + p {
         max-width: 320px;
@@ -27,7 +27,7 @@
     left: 50%;
     text-align: left;
     margin-left: 0;
-    transform: translate3d(0,0,0);
+    transform: translate(0,0);
 
     img {
         max-width: 415px;
@@ -44,7 +44,7 @@
     }
     &.centered {
         top: 50% !important;
-        transform: translate3d(0,-50%,0);
+        transform: translateY(-50%);
     }
 }
 


### PR DESCRIPTION
Because of IE 9, we needed to remove the 3D transition on the index page in the animation.